### PR TITLE
Make hooks local

### DIFF
--- a/flycheck-pos-tip.el
+++ b/flycheck-pos-tip.el
@@ -115,11 +115,11 @@ TTY frames."
                 flycheck-display-errors-function
                 #'flycheck-pos-tip-error-messages)
           (dolist (hook hooks)
-            (add-hook hook #'flycheck-pos-tip-hide-messages)))
+            (add-hook hook #'flycheck-pos-tip-hide-messages nil t)))
       (setq flycheck-display-errors-function
             flycheck-pos-tip-old-display-function)
       (dolist (hook hooks)
-        (remove-hook hook 'flycheck-pos-tip-hide-messages)))))
+        (remove-hook hook 'flycheck-pos-tip-hide-messages t)))))
 
 (provide 'flycheck-pos-tip)
 


### PR DESCRIPTION
Probably LOCAL argument should be set when adding/removing hooks because `flycheck-pos-tip-hide-messages` executes even when flycheck-mode is not enabled.

I've found this problem when I tried to debug `pos-tip-show` function in *scratch* buffer.
For example:
`(pos-tip-show "test") C-x C-e`
Popup shows for a moment and then closes immediately because  `flycheck-pos-tip-hide-messages` was added globally to the `post-command-hook`
