### PR TITLE
Fix `flycheck-pos-tip-max-width' customize type

### DIFF
--- a/flycheck-pos-tip.el
+++ b/flycheck-pos-tip.el
@@ -49,7 +49,8 @@
 (defcustom flycheck-pos-tip-max-width nil
   "If non-nil, the max width of the tooltip in chars."
   :group 'flycheck-pos-tip
-  :type 'number
+  :type '(choice (const :tag "Auto" nil)
+                 (integer :tag "Characters"))
   :package-version '(flycheck-pos-tip . "0.4"))
 
 (defcustom flycheck-pos-tip-timeout 5


### PR DESCRIPTION
`nil` is not compatible with the number type, `number` is also not suitable for discrete values like the number of characters. This PR fixed this type-mismatch error in customize.